### PR TITLE
`r-reticulate` environment setup on install

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: toolchest
 Title: R Client for Toolchest
-Version: 0.7.2
+Version: 0.7.3
 Authors@R: c(
     person(given = "Bryce",
            family = "Cai",

--- a/R/tools.R
+++ b/R/tools.R
@@ -36,7 +36,7 @@ bowtie2 <- function(tool_args = "", inputs = NULL, output_path = NULL, database_
 #' manually.
 #'
 #' @param tool_args Additional arguments to be passed to Cutadapt.
-#' @param inputs Path or list of paths (client-side) to be passed in as input.
+#' @param inputs Path (client-side) to be passed in as input.
 #' @param output_path Path (client-side) where the output file will be downloaded.
 #'
 #' @examples
@@ -67,7 +67,7 @@ cutadapt <- function(tool_args, inputs = NULL, output_path = NULL) {
 #' manually.
 #'
 #' @param tool_args (optional) Additional arguments to be passed to Kraken 2.
-#' @param inputs Path or list of paths (client-side) to be passed in as input.
+#' @param inputs Path (client-side) to be passed in as input.
 #' @param output_path Path (client-side) where the output will be downloaded.
 #' @param database_name (optional) Name (string) of database to use for Kraken 2 alignment.
 #' @param database_version (optional) Version (string) of database to use for Kraken 2 alignment.

--- a/R/util.R
+++ b/R/util.R
@@ -1,5 +1,5 @@
-#' Helper function that sanitizes args removes blank args (to be handled by
-#' the Python client) and executes the corresponding Python client call.
+#' Helper function that sanitizes args by removing blank args (to be handled by
+#' the Python client) and executing the corresponding Python client call.
 #'
 #' @param tool Tool to be used (python function, from reticulate-based python module).
 #' @param args List containing keyword arguments to be passed in to tool.

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -11,7 +11,6 @@
   reticulate::virtualenv_create("r-reticulate")
   reticulate::virtualenv_install("r-reticulate", "toolchest_client")
 
-  # reticulate::py_install("toolchest_client", method = "auto", pip = TRUE)
   reticulate::configure_environment("toolchest_client")
   toolchest_client <<- reticulate::import("toolchest_client", delay_load = TRUE)
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -9,7 +9,11 @@
 
   packageStartupMessage("Configuring reticulate...")
   reticulate::virtualenv_create("r-reticulate")
-  reticulate::virtualenv_install("r-reticulate", "toolchest_client")
+  reticulate::virtualenv_install(
+    envname = "r-reticulate",
+    packages = "toolchest_client",
+    ignore_installed = TRUE
+  )
 
   reticulate::configure_environment("toolchest_client")
   toolchest_client <<- reticulate::import("toolchest_client", delay_load = TRUE)

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -7,7 +7,11 @@
 .onLoad <- function(libname, pkgname) {
   packageStartupMessage("Installing Toolchest client... ")
 
-  reticulate::py_install("toolchest_client", method = "auto", pip = TRUE)
+  packageStartupMessage("Configuring reticulate...")
+  reticulate::virtualenv_create("r-reticulate")
+  reticulate::virtualenv_install("r-reticulate", "toolchest_client")
+
+  # reticulate::py_install("toolchest_client", method = "auto", pip = TRUE)
   reticulate::configure_environment("toolchest_client")
   toolchest_client <<- reticulate::import("toolchest_client", delay_load = TRUE)
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -70,6 +70,7 @@ You can install the development version from [GitHub](https://github.com/) with:
 ```r
 # install.packages("devtools") # uncomment to install devtools (prereq package)
 devtools::install_github("trytoolchest/toolchest-client-r")
+library(toolchest)
 ```
     
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ You can install the development version from
 ``` r
 # install.packages("devtools") # uncomment to install devtools (prereq package)
 devtools::install_github("trytoolchest/toolchest-client-r")
+library(toolchest)
 ```
 
 ## Configuration

--- a/man/cutadapt.Rd
+++ b/man/cutadapt.Rd
@@ -9,7 +9,7 @@ cutadapt(tool_args, inputs = NULL, output_path = NULL)
 \arguments{
 \item{tool_args}{Additional arguments to be passed to Cutadapt.}
 
-\item{inputs}{Path or list of paths (client-side) to be passed in as input.}
+\item{inputs}{Path (client-side) to be passed in as input.}
 
 \item{output_path}{Path (client-side) where the output file will be downloaded.}
 }

--- a/man/dot-do.toolchest.call.Rd
+++ b/man/dot-do.toolchest.call.Rd
@@ -2,8 +2,8 @@
 % Please edit documentation in R/util.R
 \name{.do.toolchest.call}
 \alias{.do.toolchest.call}
-\title{Helper function that sanitizes args removes blank args (to be handled by
-the Python client) and executes the corresponding Python client call.}
+\title{Helper function that sanitizes args by removing blank args (to be handled by
+the Python client) and executing the corresponding Python client call.}
 \usage{
 .do.toolchest.call(tool, args)
 }
@@ -13,6 +13,6 @@ the Python client) and executes the corresponding Python client call.}
 \item{args}{List containing keyword arguments to be passed in to tool.}
 }
 \description{
-Helper function that sanitizes args removes blank args (to be handled by
-the Python client) and executes the corresponding Python client call.
+Helper function that sanitizes args by removing blank args (to be handled by
+the Python client) and executing the corresponding Python client call.
 }

--- a/man/kraken2.Rd
+++ b/man/kraken2.Rd
@@ -15,7 +15,7 @@ kraken2(
 \arguments{
 \item{tool_args}{(optional) Additional arguments to be passed to Kraken 2.}
 
-\item{inputs}{Path or list of paths (client-side) to be passed in as input.}
+\item{inputs}{Path (client-side) to be passed in as input.}
 
 \item{output_path}{Path (client-side) where the output will be downloaded.}
 


### PR DESCRIPTION
Changes the way `reticulate` installs the python package upon loading/installing the R package. The `r-reticulate` environment is now manually installed with `reticulate::virtualenv_create()` and `reticulate::virtualenv_install()`, in place of `reticulate::py_install()`.

Note that this doesn't fully replicate the install model used by `tensorflow`. There are more improvements that we can make on that front, such as separating the actual install (of the python client) from the R package load, but I'm moving them down the priority list for now.