### PR TITLE
`pysam` install fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: toolchest
 Title: R Client for Toolchest
-Version: 0.7.3
+Version: 0.7.4
 Authors@R: c(
     person(given = "Bryce",
            family = "Cai",

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -25,7 +25,7 @@ reset_setuptools = (LooseVersion(setuptools_version) >= LooseVersion('58.0.2'))
   reticulate::virtualenv_install(
     envname = "r-reticulate",
     packages = "toolchest_client",
-    ignore_installed = TRUE,
+    ignore_installed = TRUE
   )
 
   # reticulate::configure_environment("toolchest_client")

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -8,11 +8,11 @@
   packageStartupMessage("Installing Toolchest client... ")
 
   packageStartupMessage("Configuring reticulate...")
-  reticulate::virtualenv_create("r-reticulate")
-  reticulate::virtualenv_install(
+  reticulate::conda_create("r-reticulate")
+  reticulate::conda_install(
     envname = "r-reticulate",
     packages = "toolchest_client",
-    ignore_installed = TRUE
+    pip_ignore_installed = TRUE
   )
 
   reticulate::configure_environment("toolchest_client")

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -16,10 +16,12 @@ setuptools_version = setuptools.__version__
 reset_setuptools = (LooseVersion(setuptools_version) >= LooseVersion('58.0.2'))
 ")
     if (version_check$reset_setuptools) {
+      packageStartupMessage("Incompatible version of setuptools detected. Reinstalling setuptools...")
       reticulate::virtualenv_remove("r-reticulate", "setuptools")
       reticulate::virtualenv_install("r-reticulate", "setuptools==58.0.0")
     }
   } else {
+    packageStartupMessage("Creating Python virtual environment...")
     reticulate::virtualenv_create("r-reticulate", setuptools_version = "58.0.0")
   }
   reticulate::virtualenv_install(

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -28,7 +28,7 @@ reset_setuptools = (LooseVersion(setuptools_version) >= LooseVersion('58.0.2'))
     ignore_installed = TRUE,
   )
 
-  reticulate::configure_environment("toolchest_client")
+  # reticulate::configure_environment("toolchest_client")
   toolchest_client <<- reticulate::import("toolchest_client", delay_load = TRUE)
 
   packageStartupMessage("The Toolchest client has been installed!")

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -12,6 +12,7 @@
   reticulate::conda_install(
     envname = "r-reticulate",
     packages = "toolchest_client",
+    pip = TRUE,
     pip_ignore_installed = TRUE
   )
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -8,12 +8,11 @@
   packageStartupMessage("Installing Toolchest client... ")
 
   packageStartupMessage("Configuring reticulate...")
-  reticulate::conda_create("r-reticulate")
-  reticulate::conda_install(
+  reticulate::virtualenv_create("r-reticulate")
+  reticulate::virtualenv_install(
     envname = "r-reticulate",
     packages = "toolchest_client",
-    pip = TRUE,
-    pip_ignore_installed = TRUE
+    ignore_installed = TRUE
   )
 
   reticulate::configure_environment("toolchest_client")

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -9,8 +9,16 @@
 
   packageStartupMessage("Configuring reticulate...")
   if (reticulate::virtualenv_exists("r-reticulate")) {
-    reticulate::virtualenv_remove("r-reticulate", "setuptools")
-    reticulate::virtualenv_install("r-reticulate", "setuptools==58.0.0")
+    version_check <- reticulate::py_run_string("from distutils.version import LooseVersion
+import setuptools
+
+setuptools_version = setuptools.__version__
+reset_setuptools = (LooseVersion(setuptools_version) >= LooseVersion('58.0.2'))
+")
+    if (version_check$reset_setuptools) {
+      reticulate::virtualenv_remove("r-reticulate", "setuptools")
+      reticulate::virtualenv_install("r-reticulate", "setuptools==58.0.0")
+    }
   } else {
     reticulate::virtualenv_create("r-reticulate", setuptools_version = "58.0.0")
   }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -8,12 +8,16 @@
   packageStartupMessage("Installing Toolchest client... ")
 
   packageStartupMessage("Configuring reticulate...")
-  reticulate::virtualenv_create("r-reticulate")
+  if (reticulate::virtualenv_exists("r-reticulate")) {
+    reticulate::virtualenv_remove("r-reticulate", "setuptools")
+    reticulate::virtualenv_install("r-reticulate", "setuptools==58.0.0")
+  } else {
+    reticulate::virtualenv_create("r-reticulate", setuptools_version = "58.0.0")
+  }
   reticulate::virtualenv_install(
     envname = "r-reticulate",
     packages = "toolchest_client",
     ignore_installed = TRUE,
-    setuptools_version = "58.0.0"
   )
 
   reticulate::configure_environment("toolchest_client")

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -12,7 +12,8 @@
   reticulate::virtualenv_install(
     envname = "r-reticulate",
     packages = "toolchest_client",
-    ignore_installed = TRUE
+    ignore_installed = TRUE,
+    setuptools_version = "58.0.0"
   )
 
   reticulate::configure_environment("toolchest_client")

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -24,13 +24,13 @@ reset_setuptools = (LooseVersion(setuptools_version) >= LooseVersion('58.0.2'))
     packageStartupMessage("Creating Python virtual environment...")
     reticulate::virtualenv_create("r-reticulate", setuptools_version = "58.0.0")
   }
+
   reticulate::virtualenv_install(
     envname = "r-reticulate",
     packages = "toolchest_client",
     ignore_installed = TRUE
   )
-
-  # reticulate::configure_environment("toolchest_client")
+  reticulate::configure_environment("toolchest_client")
   toolchest_client <<- reticulate::import("toolchest_client", delay_load = TRUE)
 
   packageStartupMessage("The Toolchest client has been installed!")

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -18,6 +18,7 @@ reset_setuptools = (LooseVersion(setuptools_version) >= LooseVersion('58.0.2'))
     if (version_check$reset_setuptools) {
       packageStartupMessage("Incompatible version of setuptools detected. Reinstalling setuptools...")
       reticulate::virtualenv_remove("r-reticulate", "setuptools")
+      cat("Reinstalling")
       reticulate::virtualenv_install("r-reticulate", "setuptools==58.0.0")
     }
   } else {


### PR DESCRIPTION
Resolves the R client's issues with installing `pysam`  by enforcing `setuptools` to be version `58.0.0` within the R client. Reinstalls `setuptools` if necessary.

 Prevents the `r-reticulate` virtual env from being recreated if it already exists and a proper version of `setuptools` is detected.