### PR TITLE
fix: min python version -> 3.7, default version -> 3.9

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ URL: https://github.com/trytoolchest/toolchest-client-r
 BugReports: https://github.com/trytoolchest/toolchest-client-r/issues
 Imports:
     lifecycle,
-    reticulate (>= 1.24),
+    reticulate (>= 1.25),
     utils
 Suggests: 
     testthat (>= 3.0.0)

--- a/R/install.R
+++ b/R/install.R
@@ -42,21 +42,21 @@ install_toolchest <- function() {
 
 install_with_conda <- function() {
   # Install or update miniconda
-  # (Reticulate defaults to Python 3.8 with miniconda)
+  DEFAULT_PYTHON_VERSION <- "3.9"
   packageStartupMessage("Updating conda configuration...")
   miniconda_is_installed <- try(reticulate::install_miniconda(), silent = TRUE)
   if (!("r-reticulate" %in% reticulate::conda_list()$name)) {
-    reticulate::conda_create("r-reticulate")
+    reticulate::conda_create("r-reticulate", python_version = DEFAULT_PYTHON_VERSION)
   }
 
   # Point reticulate to miniconda
   reticulate::use_miniconda("r-reticulate", required = TRUE)
 
-  # If python is out-of-date in miniconda, force reinstall
+  # If python is out-of-date in miniconda, force conda update and env rebuild
   if (!python_is_compatible()) {
     reticulate::conda_remove("r-reticulate")
-    reticulate::install_miniconda(force = TRUE)
-    reticulate::conda_create("r-reticulate")
+    reticulate::miniconda_update()
+    reticulate::conda_create("r-reticulate", python_version = DEFAULT_PYTHON_VERSION)
     reticulate::use_miniconda("r-reticulate", required = TRUE)
   }
 
@@ -73,12 +73,9 @@ install_with_conda <- function() {
 }
 
 install_with_virtualenv <- function() {
-  # TODO: deprecate assigning a default version with reticulate 1.25
-  PYTHON_VERSION <- "3.8"
-
-  # (Reticulate 1.25+ defaults to latest version of Python, or at least 3.8)
+  # (Reticulate 1.25+ defaults to latest patch of Python 3.9)
   packageStartupMessage("Installing custom Python...")
-  python_path <- reticulate::install_python(version = PYTHON_VERSION)
+  python_path <- reticulate::install_python()
 
   packageStartupMessage("Creating custom environment...")
   reticulate::virtualenv_create("r-reticulate", python = python_path)

--- a/R/install.R
+++ b/R/install.R
@@ -74,7 +74,7 @@ install_with_conda <- function() {
 
 install_with_virtualenv <- function() {
   # TODO: deprecate assigning a default version with reticulate 1.25
-  PYTHON_VERSION <- "3.8.7"
+  PYTHON_VERSION <- "3.8"
 
   # (Reticulate 1.25+ defaults to latest version of Python, or at least 3.8)
   packageStartupMessage("Installing custom Python...")
@@ -105,7 +105,7 @@ install_with_virtualenv <- function() {
 }
 
 python_is_compatible <- function(python_path) {
-  MIN_PYTHON_VERSION <- "3.6"
+  MIN_PYTHON_VERSION <- "3.7"
 
   path_is_python <- tryCatch(python_info <- reticulate::py_discover_config(), silent = TRUE)
   if (inherits(path_is_python, "try-error")) {


### PR DESCRIPTION
Modifies:
* Minimum Python version, increased from 3.6 to **3.7** to be compatible with `boto3` phasing out support for Python 3.6 and below.
  * Forces rebuild of r-reticulate miniconda environment if its python is 3.6 or below.
* Required version of `reticulate`, increased from 1.24 to **1.25** for new functions related to Conda/Python installation.
* Conda installation: no longer reinstalls conda entirely if conda is installed but out-of-date. Applies an update instead.
* Default version of Python increased to **3.9** for both virtualenv and conda installs.

