### PR TITLE
fix: standardize output path

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: toolchest
 Title: R Client for Toolchest
-Version: 0.9.9
+Version: 0.9.14
 Authors@R: c(
     person(given = "Bryce",
            family = "Cai",

--- a/R/tools.R
+++ b/R/tools.R
@@ -66,17 +66,20 @@ bowtie2 <- function(tool_args = "", inputs, output_path = NULL, database_name = 
 #' Runs Clustal Omega via Toolchest.
 #'
 #' @param inputs Path (client-side) to a FASTA file that will be passed in as input.
-#' @param output_path (optional) Path (client-side) where the output file will be downloaded.
+#' @param output_path (optional) Path to directory where the output file(s) will be downloaded.
+#' @param output_primary_name (optional) Base name of output file.
 #' @param tool_args Additional arguments to be passed to Clustal Omega.
 #' @param is_async (optional) Whether to run a job asynchronously. Defaults to false.
 #' @return Reference to an object with output location data.
 #'
 #' @export
-clustalo <- function(tool_args = "", inputs, output_path = NULL, ...) {
+clustalo <- function(tool_args = "", inputs, output_path = NULL,
+                     output_primary_name = NULL, ...) {
   toolchest_args <- c(
     list(
       inputs = inputs,
       output_path = output_path,
+      output_primary_name = output_primary_name,
       tool_args = tool_args
     ),
     list(...)
@@ -114,17 +117,21 @@ demucs <- function(tool_args = "", inputs, output_path = NULL, ...) {
 #' Runs Diamond in BLASTp mode via Toolchest.
 #'
 #' @param inputs Path to a file that will be passed in as input. FASTA or FASTQ formats are supported (it may be gzip compressed)
-#' @param output_path (optional) File path where the output will be downloaded. Log file (diamond.log) will be downloaded in the same directory as the out file
+#' @param output_path (optional) (optional) Path to directory where the output file(s) will be downloaded.
+#'   Log file (diamond.log) will be downloaded in the same directory as the out file(s).
+#' @param output_primary_name (optional) Base name of output file.
 #' @param tool_args Additional arguments to be passed to Diamond BLASTp.
 #' @param is_async (optional) Whether to run a job asynchronously. Defaults to false.
 #' @return Reference to an object with output location data.
 #'
 #' @export
-diamond_blastp <- function(tool_args = "", inputs, output_path = NULL, ...) {
+diamond_blastp <- function(tool_args = "", inputs, output_path = NULL,
+                           output_primary_name = NULL, ...) {
   toolchest_args <- c(
     list(
       inputs = inputs,
       output_path = output_path,
+      output_primary_name = output_primary_name,
       tool_args = tool_args
     ),
     list(...)
@@ -138,17 +145,21 @@ diamond_blastp <- function(tool_args = "", inputs, output_path = NULL, ...) {
 #' Runs Diamond in BLASTx mode via Toolchest.
 #'
 #' @param inputs Path to a file that will be passed in as input. FASTA or FASTQ formats are supported (it may be gzip compressed)
-#' @param output_path (optional) File path where the output will be downloaded. Log file (diamond.log) will be downloaded in the same directory as the out file
+#' @param output_path (optional) (optional) Path to directory where the output file(s) will be downloaded.
+#'   Log file (diamond.log) will be downloaded in the same directory as the out file(s).
+#' @param output_primary_name (optional) Base name of output file.
 #' @param tool_args Additional arguments to be passed to Diamond BLASTx.
 #' @param is_async (optional) Whether to run a job asynchronously. Defaults to false.
 #' @return Reference to an object with output location data.
 #'
 #' @export
-diamond_blastx <- function(tool_args = "", inputs, output_path = NULL, ...) {
+diamond_blastx <- function(tool_args = "", inputs, output_path = NULL,
+                           output_primary_name = NULL, ...) {
   toolchest_args <- c(
     list(
       inputs = inputs,
       output_path = output_path,
+      output_primary_name = output_primary_name,
       tool_args = tool_args
     ),
     list(...)
@@ -230,7 +241,9 @@ megahit <- function(tool_args = "", read_one = NULL, read_two = NULL, output_pat
 #' Runs Diamond in BLASTx mode via Toolchest.
 #'
 #' @param inputs Path to a FASTA/FASTQ file that will be passed in as input.
-#' @param output_path (optional) Base path to where the output file(s) will be downloaded. (Functions the same way as the "-o" tag for Rapsearch.)
+#' @param output_path (optional) Path (client-side) to a directory where the output files will be downloaded.
+#' @param output_primary_name (optional) Base name of output file(s).
+#'   (Functions the same way as the "-o" tag for RAPSearch2, in combination with `output_path`.)
 #' @param tool_args (optional) Additional arguments to be passed to RAPSearch2.
 #' @param database_name (optional) Name of database to use for RAPSearch2 alignment. Defaults to SeqScreen DB.
 #' @param database_version (optional) Version of database to use for RAPSearch2 alignment. Defaults to 1.
@@ -238,13 +251,14 @@ megahit <- function(tool_args = "", read_one = NULL, read_two = NULL, output_pat
 #' @return Reference to an object with output location data.
 #'
 #' @export
-rapsearch2 <- function(tool_args = "", inputs, output_path = NULL, database_name = "rapsearch2_seqscreen",
-                       database_version = "1", ...) {
+rapsearch2 <- function(tool_args = "", inputs, output_path = NULL, output_primary_name = NULL,
+                       database_name = "rapsearch2_seqscreen", database_version = "1", ...) {
   toolchest_args <- c(
     list(
       tool_args = tool_args,
       inputs = inputs,
       output_path = output_path,
+      output_primary_name = output_primary_name,
       database_name = database_name,
       database_version = database_version
     ),

--- a/man/clustalo.Rd
+++ b/man/clustalo.Rd
@@ -4,14 +4,22 @@
 \alias{clustalo}
 \title{Clustal Omega Client}
 \usage{
-clustalo(tool_args = "", inputs, output_path = NULL, ...)
+clustalo(
+  tool_args = "",
+  inputs,
+  output_path = NULL,
+  output_primary_name = NULL,
+  ...
+)
 }
 \arguments{
 \item{tool_args}{Additional arguments to be passed to Clustal Omega.}
 
 \item{inputs}{Path (client-side) to a FASTA file that will be passed in as input.}
 
-\item{output_path}{(optional) Path (client-side) where the output file will be downloaded.}
+\item{output_path}{(optional) Path to directory where the output file(s) will be downloaded.}
+
+\item{output_primary_name}{(optional) Base name of output file.}
 
 \item{is_async}{(optional) Whether to run a job asynchronously. Defaults to false.}
 }

--- a/man/diamond_blastp.Rd
+++ b/man/diamond_blastp.Rd
@@ -4,14 +4,23 @@
 \alias{diamond_blastp}
 \title{Diamond BLASTp Client}
 \usage{
-diamond_blastp(tool_args = "", inputs, output_path = NULL, ...)
+diamond_blastp(
+  tool_args = "",
+  inputs,
+  output_path = NULL,
+  output_primary_name = NULL,
+  ...
+)
 }
 \arguments{
 \item{tool_args}{Additional arguments to be passed to Diamond BLASTp.}
 
 \item{inputs}{Path to a file that will be passed in as input. FASTA or FASTQ formats are supported (it may be gzip compressed)}
 
-\item{output_path}{(optional) File path where the output will be downloaded. Log file (diamond.log) will be downloaded in the same directory as the out file}
+\item{output_path}{(optional) (optional) Path to directory where the output file(s) will be downloaded.
+Log file (diamond.log) will be downloaded in the same directory as the out file(s).}
+
+\item{output_primary_name}{(optional) Base name of output file.}
 
 \item{is_async}{(optional) Whether to run a job asynchronously. Defaults to false.}
 }

--- a/man/diamond_blastx.Rd
+++ b/man/diamond_blastx.Rd
@@ -4,14 +4,23 @@
 \alias{diamond_blastx}
 \title{Diamond BLASTx Client}
 \usage{
-diamond_blastx(tool_args = "", inputs, output_path = NULL, ...)
+diamond_blastx(
+  tool_args = "",
+  inputs,
+  output_path = NULL,
+  output_primary_name = NULL,
+  ...
+)
 }
 \arguments{
 \item{tool_args}{Additional arguments to be passed to Diamond BLASTx.}
 
 \item{inputs}{Path to a file that will be passed in as input. FASTA or FASTQ formats are supported (it may be gzip compressed)}
 
-\item{output_path}{(optional) File path where the output will be downloaded. Log file (diamond.log) will be downloaded in the same directory as the out file}
+\item{output_path}{(optional) (optional) Path to directory where the output file(s) will be downloaded.
+Log file (diamond.log) will be downloaded in the same directory as the out file(s).}
+
+\item{output_primary_name}{(optional) Base name of output file.}
 
 \item{is_async}{(optional) Whether to run a job asynchronously. Defaults to false.}
 }

--- a/man/rapsearch2.Rd
+++ b/man/rapsearch2.Rd
@@ -4,14 +4,25 @@
 \alias{rapsearch2}
 \title{RAPSearch2 Client}
 \usage{
-rapsearch2(tool_args = "", inputs, output_path = NULL, ...)
+rapsearch2(
+  tool_args = "",
+  inputs,
+  output_path = NULL,
+  output_primary_name = NULL,
+  database_name = "rapsearch2_seqscreen",
+  database_version = "1",
+  ...
+)
 }
 \arguments{
 \item{tool_args}{(optional) Additional arguments to be passed to RAPSearch2.}
 
 \item{inputs}{Path to a FASTA/FASTQ file that will be passed in as input.}
 
-\item{output_path}{(optional) Base path to where the output file(s) will be downloaded. (Functions the same way as the "-o" tag for Rapsearch.)}
+\item{output_path}{(optional) Path (client-side) to a directory where the output files will be downloaded.}
+
+\item{output_primary_name}{(optional) Base name of output file(s).
+(Functions the same way as the "-o" tag for RAPSearch2, in combination with \code{output_path}.)}
 
 \item{database_name}{(optional) Name of database to use for RAPSearch2 alignment. Defaults to SeqScreen DB.}
 


### PR DESCRIPTION
* Refactors `output_path` to refer _only_ to a directory. If a tool needs a file name specified as well, it should be passed into the `output_primary_name` parameter.

This is a **breaking change**. The function calls for the following tools are affected:
* `clustalo`
* `diamond_blastp`
* `diamond_blastx`
* `rapsearch2`

For these tools, `output_path` formerly referred to an output **file**. The base file name should now be parsed into `output_primary_name` instead, and `output_path` should contain the directory the output file will be in.